### PR TITLE
fix: delete enforce key

### DIFF
--- a/packages/lang-jsx/index.js
+++ b/packages/lang-jsx/index.js
@@ -41,7 +41,6 @@ function langJsx(options = {}) {
 
   return {
     name: 'vite-plugin-lang-jsx',
-    enforce: 'pre',
     async transform(code, id) {
       if (!id.endsWith('.vue')) return;
 


### PR DESCRIPTION
你好, 我在使用你的plugin的时候出现了一些bug, 原因是因为我自己写的路径解析plugin, 比您的晚执行, 这将出现以下问题:

1. lang-jsx 解析了代码
2. 我的路径解析plugins完毕后发现新的模块
3. 这些新的模块并未被您的插件解析.

主要原因是代码中存在 `enfore: 'pre'` 字段. 但是它应该比我的plugins晚执行才对. 所以plugin执行的先后让用户决定会不会更好呢?