### PR TITLE
fix the bug will make the error  in the file dynamic-import-vars.ts

### DIFF
--- a/packages/dynamic-import/src/dynamic-import-vars.ts
+++ b/packages/dynamic-import/src/dynamic-import-vars.ts
@@ -160,18 +160,7 @@ export function tryFixGlobSlash(glob: string, depth = true): string | void {
   // It could be `./views*.js`, which needs to be repaired to `./views/*.js`
   glob = glob.replace(extname, '')
 
-  /* when use import(`@/${var}`) in the code, and this code's file path is the sub dir of the src, 
-  and make the src dir path name to be a alias name: @, like this:
-  ├─┬ src
-  │ ├─┬ router
-  │ │ └── dyncRoute.js
-
-  if the code 'import(`@/${var}`)' is used in dyncRoute.js, the variable glob will be the value `../*`*/
-  // this value will make the expression `glob.match(/(.*\w\/?)\*/)` in the old code to get null, 
-  // and expression `const [, importPath] = null` will occur an error with messaged 
-  //`object null is not iterable (cannot read property Symbol(Symbol.iterator))`, so I fixed the error as follow
-  
-  // const [, importPath] = glob.match(/(.*\w\/?)\*/)
+  // #20
   const [, importPath] = glob.match(/(.*\/?)\*/)
   if (!importPath.endsWith('/')) {
     // fill necessary slash

--- a/packages/dynamic-import/src/dynamic-import-vars.ts
+++ b/packages/dynamic-import/src/dynamic-import-vars.ts
@@ -160,7 +160,19 @@ export function tryFixGlobSlash(glob: string, depth = true): string | void {
   // It could be `./views*.js`, which needs to be repaired to `./views/*.js`
   glob = glob.replace(extname, '')
 
-  const [, importPath] = glob.match(/(.*\w\/?)\*/)
+  /* when use import(`@/${var}`) in the code, and this code's file path is the sub dir of the src, 
+  and make the src dir path name to be a alias name: @, like this:
+  ├─┬ src
+  │ ├─┬ router
+  │ │ └── dyncRoute.js
+
+  if the code 'import(`@/${var}`)' is used in dyncRoute.js, the variable glob will be the value `../*`*/
+  // this value will make the expression `glob.match(/(.*\w\/?)\*/)` in the old code to get null, 
+  // and expression `const [, importPath] = null` will occur an error with messaged 
+  //`object null is not iterable (cannot read property Symbol(Symbol.iterator))`, so I fixed the error as follow
+  
+  // const [, importPath] = glob.match(/(.*\w\/?)\*/)
+  const [, importPath] = glob.match(/(.*\/?)\*/)
   if (!importPath.endsWith('/')) {
     // fill necessary slash
     // `./views*` -> `./views/*`


### PR DESCRIPTION
fix the bug will make the error `object null is not iterable (cannot read property Symbol(Symbol.iterator))` in the file dynamic-import-vars.ts

---

```js
  /*
  When use import(`@/${var}`) in the code, and this code's file path is the sub dir of the src, 
  and make the src dir path name to be a alias name: @, like this:
  ├─┬ src
  │ ├─┬ router
  │ │ └── dyncRoute.js

  If the code 'import(`@/${var}`)' is used in dyncRoute.js, the variable glob will be the value `../*`
  */
  // this value will make the expression `glob.match(/(.*\w\/?)\*/)` in the old code to get null, 
  // and expression `const [, importPath] = null` will occur an error with messaged 
  //`object null is not iterable (cannot read property Symbol(Symbol.iterator))`, so I fixed the error as follow
  
  // const [, importPath] = glob.match(/(.*\w\/?)\*/)
  //                                    👇🏻
  const [, importPath] = glob.match(/(.*\/?)\*/)
```
https://github.com/caoxiemeihao/vite-plugins/blob/ac55271950c5c0e7977a153eb44c5ba9a59ba095/packages/dynamic-import/src/dynamic-import-vars.ts#L163