### PR TITLE
fix: only alias - import(@/)

### DIFF
--- a/packages/dynamic-import/package.json
+++ b/packages/dynamic-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-dynamic-import",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "description": "Enhance Vite builtin dynamic import",
   "main": "dist/index.js",
   "repository": {

--- a/packages/dynamic-import/src/alias.ts
+++ b/packages/dynamic-import/src/alias.ts
@@ -67,7 +67,7 @@ export class AliasContext {
         normalReplacement,
       )
       if (relativePath === '') {
-        relativePath = '.'
+        relativePath = /* 🚧-③ */'.'
       }
       const relativeImportee = relativePath + '/' + ipte
         .replace(find, '')


### PR DESCRIPTION
# vite-plugin-dynamic-import@0.8.1

# Fix

- only alias importee #20  
- corrected import path `import('@/views/x.js')` -> `import('./views/x.js')`